### PR TITLE
Improve existing target

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+artifacts
+corpus
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = { version = "1.2.0", features = ["derive"] }
 libfuzzer-sys = "0.4"
 
 [dependencies.bvh]


### PR DESCRIPTION
The existing target was adapted from example code and is somewhat limited in the inputs it tests. This PR allows a much wider range of inputs. It found 6 detects (the runs can be seen [here](https://mayhem.forallsecure.com/ysthakur/bvh?coverage_target=bvh-fuzz)). It seems like `BVH::build` should return a `Result` instead of having assertions? It looks like it should also check for the zero vector and return an error in that case since that may be causing the stack overflow.